### PR TITLE
timeTouch: change detecting code using indexedDB and Navigation-Timing API

### DIFF
--- a/.sizecache.json
+++ b/.sizecache.json
@@ -1,1 +1,1 @@
-{"":{"version":0.4,"tips":{"master":"51ac523ba2b04bdeeb698714a467abd498969003"}}," last run":{"hammer-time.js":{"":5677},"dist/hammer-time.min.js":{"":2617}},"master":{"hammer-time.js":{"":3994},"dist/hammer-time.min.js":{"":1667}}}
+{"":{"version":0.4,"tips":{"master":"51ac523ba2b04bdeeb698714a467abd498969003"}}," last run":{"hammer-time.js":{"":5432},"dist/hammer-time.min.js":{"":2468}},"master":{"hammer-time.js":{"":3994},"dist/hammer-time.min.js":{"":1667}}}

--- a/hammer-time.js
+++ b/hammer-time.js
@@ -31,15 +31,7 @@ window.Hammer = window.Hammer || {};
 var touchMatchNone = /touch-action[:][\s]*(none)[^;'"]*/;
 var touchMatchManipulation = /touch-action[:][\s]*(manipulation)[^;'"]*/;
 var touchMatch = /touch-action/;
-var iOS = ( navigator.userAgent.match( /(iPad|iPhone|iPod)/g ) ? true : false );
-var gl = ( function() {
-	try {
-		var canvas = document.createElement( "canvas" );
-		return !!( window.WebGLRenderingContext && ( canvas.getContext( "webgl" ) ||
-			canvas.getContext( "experimental-webgl" ) ) );
-	}
-	catch ( e ) { return false; } } )();
-var timeTouch = gl && iOS;
+var timeTouch = /(iP(ad|hone|od))/.test( navigator.userAgent ) && ( "indexedDB" in window || !!window.performance );
 
 window.Hammer.time = {
 


### PR DESCRIPTION
I change detecting code using indexedDB and window.performance
http://caniuse.com/#search=Navigation%20Timing
- iOS8+ Safari and Webview support indexedDB. but, iOS9 Webview does not support indexedDB.
- iOS 8.0 Safari and Webview support Navigation-Timing API but, it is removed for poor performance in iOS 8.1
- Navigation-Timing API is back on iOS9 Safari and Webview (http://www.mobilexweb.com/blog/ios9-safari-for-web-developers)

I checked following browsers

| Browser | as-is(using WebGL) | to-be (using indexedDB and Navigation-Timing) |
| --- | --- | --- |
| iOS7 Safari | false | false |
| iOS7 Webview | false | false |
| iOS8 Safari | true | true |
| iOS8 Webview | true | true |
| iOS9 Safari | true | true |
| iOS9 Webview | true | true |

Reference #17 
