### PR TITLE
Enables the polyfill on pages running from the iOS home screen

### DIFF
--- a/hammer-time.js
+++ b/hammer-time.js
@@ -16,9 +16,11 @@
 	                  ( window.DocumentTouch && document instanceof DocumentTouch );
 	var nativeTouchAction = document.documentElement.style[ "touch-action" ] !== undefined ||
 			                            document.documentElement.style[ "-ms-touch-action" ];
+  // iOS running pages from the homescreen still have the delay
+  var standalone = window.navigator.standalone;
 
 // If there is native touch action bail the hammer has already dropped
-if ( nativeTouchAction || !touchevents || !MO ) {
+if ( (nativeTouchAction && !standalone) || !touchevents || !MO ) {
 	return;
 }
 


### PR DESCRIPTION
On iOS, pages running from the home screen still have the delay.